### PR TITLE
fixing issue #8 - this creates a new column 'twilio_list_id

### DIFF
--- a/db/migrate/20121001233531_add_twilio_id_field.rb
+++ b/db/migrate/20121001233531_add_twilio_id_field.rb
@@ -1,0 +1,16 @@
+class AddTwilioIdField < ActiveRecord::Migration
+  class CallList < ActiveRecord::Base
+  end
+
+  def up
+    add_column :call_lists, :twilio_list_id, :integer
+    CallList.reset_column_information
+    CallList.all.each do |call_list|
+      call_list.update_attributes!(:twilio_list_id => call_list[:id])
+    end
+  end
+
+  def down
+    remove_column :call_lists, :twilio_list_id
+  end
+end


### PR DESCRIPTION
which during the migration is populated with the ID of the respective call_list for backwards compatibility, and updates the controller, models, and views to use this instead of ID. This is a unique column and can be changed by editing the list.

let me know if there is anything glaringly wrong, or if I could do anything better.
