### PR TITLE
fixing issue #8 - this creates a new column 'twilio_list_id'

### DIFF
--- a/app/controllers/call_lists_controller.rb
+++ b/app/controllers/call_lists_controller.rb
@@ -5,7 +5,7 @@ class CallListsController < ApplicationController
   # GET /call_lists
   # GET /call_lists.json
   def index
-    @call_lists = CallList.all
+    @call_lists = CallList.order(:twilio_list_id)
 
     respond_to do |format|
       format.html # index.html.erb

--- a/app/models/call_list.rb
+++ b/app/models/call_list.rb
@@ -2,6 +2,7 @@ class CallList < ActiveRecord::Base
   after_save :add_call_list_membership
   validates :name, :uniqueness => true, :presence => true
   validate :must_have_owners
+  validates :twilio_list_id, :uniqueness => true, :presence => true, :numericality => {:only_integer => true}
 
   has_many :call_list_owners, :dependent => :destroy
   has_many :owners, :through => :call_list_owners, :source => :user

--- a/app/views/call_lists/_form.html.erb
+++ b/app/views/call_lists/_form.html.erb
@@ -25,6 +25,12 @@
     <%= f.label :email %><br />
     <%= f.text_field :email %>
   </div>
+
+  <div class="field">
+    <%= f.label "Twilio List ID" %><br />
+    <%= f.text_field :twilio_list_id %><br />
+  </div>
+
   <br/> 
   <b>Owner(s):</b>
   <div class="field">

--- a/app/views/call_lists/_listing.html.erb
+++ b/app/views/call_lists/_listing.html.erb
@@ -1,7 +1,7 @@
 <table>
   <thead>
   <tr>
-    <th>ID</th>
+    <th>Twilio List ID</th>
     <th>Name</th>
     <th>Owner(s)</th>
     <th>Oncall(s)</th>
@@ -12,7 +12,7 @@
   <tbody>
 <% @call_lists.each do |call_list| %>
   <tr>
-    <td class='cell_link'><%= link_to call_list.id, call_list %></td>
+    <td class='cell_link'><%= link_to call_list.twilio_list_id, call_list %></td>
     <td class='cell_link'><%= link_to call_list.name, call_list %></td>
     <td><%= call_list.owners_names.join(", ") %></td>
     <td><%= call_list.current_oncalls.map{|o|o.user.username}.join(", ") %></td>

--- a/app/views/call_lists/show.html.erb
+++ b/app/views/call_lists/show.html.erb
@@ -2,7 +2,7 @@
 
   <b>Basic Info</b><br/>
   <div class="grid_12 content_box">
-    ID: <%= @call_list.id %><br/>
+    Twilio List ID: <%= @call_list.twilio_list_id %><br/>
     Name: <%= @call_list.name %><br/>
     Phonetic Name: <%= @call_list.phonetic_name %><br/>
     Owners: <%= @call_list.owners.map{|user| user.username}.join(", ") %><br/>

--- a/app/views/twilio_call_escalations/call_list_menu.xml.erb
+++ b/app/views/twilio_call_escalations/call_list_menu.xml.erb
@@ -6,7 +6,7 @@
         <Pause length="1"/>
         <Say>Call list directory</Say>
 <% @call_lists.each do |call_list| %>
-        <Say><%= "#{call_list.phonetic_name || call_list.name} ID #{call_list.id}"%></Say>        
+        <Say><%= "#{call_list.phonetic_name || call_list.name} ID #{call_list.twilio_list_id}"%></Say>        
         <Pause length="1"/>
 <% end %>
         <Say>Are you still there? Enter the call list ID, followed by the pound sign.</Say>

--- a/db/migrate/20121001233531_add_twilio_id_field.rb
+++ b/db/migrate/20121001233531_add_twilio_id_field.rb
@@ -1,0 +1,16 @@
+class AddTwilioIdField < ActiveRecord::Migration
+  class CallList < ActiveRecord::Base
+  end
+
+  def up
+    add_column :call_lists, :twilio_list_id, :integer
+    CallList.reset_column_information
+    CallList.all.each do |call_list|
+      call_list.update_attributes!(:twilio_list_id => call_list[:id])
+    end
+  end
+
+  def down
+    remove_column :call_lists, :twilio_list_id
+  end
+end


### PR DESCRIPTION
which during the migration is populated with the ID of the respective call_list for backwards compatibility, and updates the controller, models, and views to use this instead of ID. This is a unique column and can be changed by editing the list.

let me know if there is anything glaringly wrong, or if I could do anything better.
