### PR TITLE
fixing issue #14 - don't display the auto-assignment bits on the call list if it is not enabled

### DIFF
--- a/app/views/call_lists/show.html.erb
+++ b/app/views/call_lists/show.html.erb
@@ -58,7 +58,7 @@
   <% end %>
   </div>
 <div class="clear"></div>
-<% if @call_list.oncall_assignments_gen %>
+<% if @call_list.oncall_assignments_gen.enable %>
 <b>Oncall Auto-assignment</b><br/>
 <div class="grid_12 content_box">
 Enable: <%= @call_list.oncall_assignments_gen.enable == true ? 'yes' : 'no' %><br/>


### PR DESCRIPTION
simple fix
