### PR TITLE
fixing friendly_id slug for call_lists for ruby 1.8.7

### DIFF
--- a/app/models/call_list.rb
+++ b/app/models/call_list.rb
@@ -1,6 +1,6 @@
 class CallList < ActiveRecord::Base
   extend FriendlyId
-  friendly_id :name, use: :slugged
+  friendly_id :name, :use => :slugged
 
   after_save :add_call_list_membership
   validates :name, :uniqueness => true, :presence => true


### PR DESCRIPTION
I forgot to test on ruby 1.8.7 - my bad.

this change works for both 1.9.3 and 1.8.7
